### PR TITLE
chore: default agents to workspace dir

### DIFF
--- a/agents/EMP_0001.md
+++ b/agents/EMP_0001.md
@@ -1,7 +1,7 @@
 ---
 name: sisyphus
 description: "Sisyphus — default orchestrator (recommended model: anthropic/claude-opus-4-5)"
-working_directory: ${REPO_ROOT}
+working_directory: ${REPO_ROOT}/workspace
 launcher: codex
 launcher_args: []
 skills: []

--- a/agents/EMP_0002.md
+++ b/agents/EMP_0002.md
@@ -1,7 +1,7 @@
 ---
 name: oracle
 description: "oracle — architecture/review/strategy (recommended model: openai/gpt-5.2)"
-working_directory: ${REPO_ROOT}
+working_directory: ${REPO_ROOT}/workspace
 launcher: codex
 launcher_args: []
 skills: []

--- a/agents/EMP_0003.md
+++ b/agents/EMP_0003.md
@@ -1,7 +1,7 @@
 ---
 name: librarian
 description: "librarian — multi-repo analysis & doc lookup (recommended model: opencode/glm-4.7-free)"
-working_directory: ${REPO_ROOT}
+working_directory: ${REPO_ROOT}/workspace
 launcher: codex
 launcher_args: []
 skills: []

--- a/agents/EMP_0004.md
+++ b/agents/EMP_0004.md
@@ -1,7 +1,7 @@
 ---
 name: explore
 description: "explore — fast codebase exploration (recommended model: grok/gemini/haiku)"
-working_directory: ${REPO_ROOT}
+working_directory: ${REPO_ROOT}/workspace
 launcher: codex
 launcher_args: []
 skills: []

--- a/agents/EMP_0005.md
+++ b/agents/EMP_0005.md
@@ -1,7 +1,7 @@
 ---
 name: frontend-ui-ux-engineer
 description: "frontend-ui-ux-engineer — designer turned dev (recommended model: google/gemini-3-pro-preview)"
-working_directory: ${REPO_ROOT}
+working_directory: ${REPO_ROOT}/workspace
 launcher: codex
 launcher_args: []
 skills: []

--- a/agents/EMP_0006.md
+++ b/agents/EMP_0006.md
@@ -1,7 +1,7 @@
 ---
 name: document-writer
 description: "document-writer — technical writing (recommended model: google/gemini-3-flash)"
-working_directory: ${REPO_ROOT}
+working_directory: ${REPO_ROOT}/workspace
 launcher: codex
 launcher_args: []
 skills: []

--- a/agents/EMP_0007.md
+++ b/agents/EMP_0007.md
@@ -1,7 +1,7 @@
 ---
 name: multimodal-looker
 description: "multimodal-looker — PDF/image/diagram analysis (recommended model: google/gemini-3-flash)"
-working_directory: ${REPO_ROOT}
+working_directory: ${REPO_ROOT}/workspace
 launcher: codex
 launcher_args: []
 skills: []


### PR DESCRIPTION
Sets `working_directory: ${REPO_ROOT}/workspace` for all `agents/EMP_*.md` so agents run from the local workspace by default.

Note: `workspace/` remains untracked locally and is not included in this PR.
